### PR TITLE
Fix par packing

### DIFF
--- a/projects/Gibbed.Yakuza0.FileFormats/ArchiveFile.cs
+++ b/projects/Gibbed.Yakuza0.FileFormats/ArchiveFile.cs
@@ -227,7 +227,7 @@ namespace Gibbed.Yakuza0.FileFormats
                 }
             }
 
-            var endian = this._Endian;
+            var endian = Endian.Big;
 
             byte[] directoryTableBytes;
             using (var temp = new MemoryStream())


### PR DESCRIPTION
when creating a par file all offsets, flags, etc. must be big endian